### PR TITLE
Implement basic user profile and settings

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "@devexpress/dx-react-chart-material-ui": "^2.6.0",
     "@devexpress/dx-react-core": "^2.6.0",
     "@material-ui/core": "^4.9.9",
+    "@material-ui/icons": "^4.9.1",
     "@testing-library/jest-dom": "^5.3.0",
     "@testing-library/react": "^10.0.2",
     "@testing-library/user-event": "^10.0.1",
@@ -18,7 +19,6 @@
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
-    "react-sidebar": "^3.0.2",
     "reactstrap": "^8.4.1"
   },
   "scripts": {

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -27,8 +27,7 @@ function App() {
         return component;
       }
 
-      // return <Redirect to="/login" />;
-      return component;
+      return <Redirect to="/login" />;
     },
     [userId]
   );

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -27,7 +27,8 @@ function App() {
         return component;
       }
 
-      return <Redirect to="/login" />;
+      // return <Redirect to="/login" />;
+      return component;
     },
     [userId]
   );
@@ -46,32 +47,66 @@ function App() {
   return (
     <>
       <Router>
-        <Navigation userId={userId} setUserId={setUserId} />
-        <Switch>
-          <Route
-            path="/"
-            exact
-            render={() => showIfAuthed(<>You logged in!</>)}
-          />
-          <Route
-            path="/login"
-            exact
-            render={() => showIfNotAuthed(<Login setUserId={setUserId} />)}
-          />
-          <Route
-            path="/register"
-            exact
-            render={() => showIfNotAuthed(<Register setUserId={setUserId} />)}
-          />
-          <Route path="/dashboard" exact component={MainDashboard} />
-          <Route path="/profile" exact component={UserProfile} />
-          <Route path="/exercise" exact component={ExercisePage} />
-          <Route path="/nutrition" exact component={NutritionPage} />
-          <Route path="/settings" exact component={SettingsPage} />
-          <Route path="/dbgraph" exact component={DashboardGraph} />
-          <Route path="/exgraph" exact component={ExerciseGraph} />
-          <Route path="/nugraph" exact component={NutritionGraph} />
-        </Switch>
+        <Navigation
+          userId={userId}
+          setUserId={setUserId}
+          component={
+            <Switch>
+              <Route
+                path="/"
+                exact
+                render={() => showIfAuthed(<MainDashboard />)}
+              />
+              <Route
+                path="/login"
+                exact
+                render={() => showIfNotAuthed(<Login setUserId={setUserId} />)}
+              />
+              <Route
+                path="/register"
+                exact
+                render={() =>
+                  showIfNotAuthed(<Register setUserId={setUserId} />)
+                }
+              />
+              <Route
+                path="/profile"
+                exact
+                render={() => showIfAuthed(<UserProfile />)}
+              />
+              <Route
+                path="/exercise"
+                exact
+                render={() => showIfAuthed(<ExercisePage />)}
+              />
+              <Route
+                path="/nutrition"
+                exact
+                render={() => showIfAuthed(<NutritionPage />)}
+              />
+              <Route
+                path="/settings"
+                exact
+                render={() => showIfAuthed(<SettingsPage />)}
+              />
+              <Route
+                path="/dbgraph"
+                exact
+                render={() => showIfAuthed(<DashboardGraph />)}
+              />
+              <Route
+                path="/exgraph"
+                exact
+                render={() => showIfAuthed(<ExerciseGraph />)}
+              />
+              <Route
+                path="/nugraph"
+                exact
+                render={() => showIfAuthed(<NutritionGraph />)}
+              />
+            </Switch>
+          }
+        />
       </Router>
     </>
   );

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -72,7 +72,7 @@ function App() {
               <Route
                 path="/profile"
                 exact
-                render={() => showIfAuthed(<UserProfile />)}
+                render={(props) => showIfAuthed(<UserProfile {...props} />)}
               />
               <Route
                 path="/exercise"

--- a/client/src/components/NavBar.js
+++ b/client/src/components/NavBar.js
@@ -1,22 +1,10 @@
 import React from "react";
-// import {
-//   Route,
-//   Link,
-//   BrowserRouter as Router,
-//   Switch,
-//   Redirect,
-// } from "react-router-dom";
+import { Button } from "reactstrap";
+import { NavLink } from "react-router-dom";
+
 //Stylesheet
 import "../css/NavBar.css";
-//Components
-import Navigation from "./Navigation";
-import Login from "./Login";
-import Register from "./Register";
-import MainDashboard from "./MainDashboard";
-import UserProfile from "./UserProfile";
-import ExercisePage from "./ExercisePage";
-import NutritionPage from "./NutritionPage";
-import SettingsPage from "./SettingsPage";
+
 //Icons
 import dashboardIcon from "../assets/dashboardicon.png";
 import profileicon from "../assets/profileicon.png";
@@ -24,44 +12,56 @@ import exerciseicon from "../assets/exerciseicon.png";
 import nutritionicon from "../assets/nutritionicon.png";
 import settingsicon from "../assets/settingsicon.png";
 
-function NavBar() {
+function NavBar({ userId, setUserId }) {
+  const handleClick = () => {
+    if (userId) {
+      setUserId(null);
+    } else {
+    }
+  };
+
   return (
     <div className="sidebar">
       <div className="logo">
         <img src={dashboardIcon} alt="" className="logoImg" />
-        <a className="teamName">Team Seg_Fault</a>
+        <span className="teamName">Team Seg_Fault</span>
       </div>
       <div className="content">
-        <a className="routeLink" href="/dashboard">
+        <NavLink className="routeLink" to="/dashboard">
           <div className="barItem">
             <img src={dashboardIcon} alt="" className="icon" />
-            <a className="sidebarlink">Dashboard</a>
+            <span className="sidebarlink">Dashboard</span>
           </div>
-        </a>
-        <a className="routeLink" href="/profile">
+        </NavLink>
+        <NavLink className="routeLink" to="/profile">
           <div className="barItem">
             <img src={profileicon} alt="" className="icon" />
-            <a className="sidebarlink">My Profile</a>
+            <span className="sidebarlink">My Profile</span>
           </div>
-        </a>
-        <a className="routeLink" href="/exercise">
+        </NavLink>
+        <NavLink className="routeLink" to="/exercise">
           <div className="barItem">
             <img src={exerciseicon} alt="" className="icon" />
-            <a className="sidebarlink">Exercise</a>
+            <span className="sidebarlink">Exercise</span>
           </div>
-        </a>
-        <a className="routeLink" href="/nutrition">
+        </NavLink>
+        <NavLink className="routeLink" to="/nutrition">
           <div className="barItem">
             <img src={nutritionicon} alt="" className="icon" />
-            <a className="sidebarlink">Nutrition</a>
+            <span className="sidebarlink">Nutrition</span>
           </div>
-        </a>
-        <a className="routeLink" href="/settings">
+        </NavLink>
+        <NavLink className="routeLink" to="/settings">
           <div className="barItem">
             <img src={settingsicon} alt="" className="icon" />
-            <a className="sidebarlink">Settings</a>
+            <span className="sidebarlink">Settings</span>
           </div>
-        </a>
+        </NavLink>
+        {userId && (
+          <Button color="secondary" onClick={handleClick}>
+            Sign Out
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/Navigation.js
+++ b/client/src/components/Navigation.js
@@ -1,38 +1,139 @@
 import React, { useState } from "react";
-import { Button } from "reactstrap";
-import Sidebar from "react-sidebar";
+import clsx from "clsx";
 import NavBar from "./NavBar";
+import {
+  AppBar,
+  CssBaseline,
+  Drawer,
+  IconButton,
+  Toolbar,
+  Typography,
+} from "@material-ui/core";
+import { makeStyles, useTheme } from "@material-ui/core/styles";
+import ChevronLeftIcon from "@material-ui/icons/ChevronLeft";
+import ChevronRightIcon from "@material-ui/icons/ChevronRight";
+import MenuIcon from "@material-ui/icons/Menu";
 
-const Navigation = ({ userId, setUserId }) => {
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+// Taken largely from https://material-ui.com/components/drawers/
 
-  const handleClick = () => {
-    if (userId) {
-      setUserId(null);
-    } else {
-    }
-  };
+const drawerWidth = 300;
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: "flex",
+  },
+  appBar: {
+    transition: theme.transitions.create(["margin", "width"], {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+  },
+  appBarShift: {
+    width: `calc(100% - ${drawerWidth}px)`,
+    marginLeft: drawerWidth,
+    transition: theme.transitions.create(["margin", "width"], {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+  },
+  menuButton: {
+    marginRight: theme.spacing(2),
+  },
+  hide: {
+    display: "none",
+  },
+  drawer: {
+    width: drawerWidth,
+    flexShrink: 0,
+  },
+  drawerPaper: {
+    width: drawerWidth,
+  },
+  drawerHeader: {
+    display: "flex",
+    alignItems: "center",
+    padding: theme.spacing(0, 1),
+    // necessary for content to be below app bar
+    ...theme.mixins.toolbar,
+    justifyContent: "flex-end",
+  },
+  content: {
+    flexGrow: 1,
+    padding: theme.spacing(3),
+    transition: theme.transitions.create("margin", {
+      easing: theme.transitions.easing.sharp,
+      duration: theme.transitions.duration.leavingScreen,
+    }),
+    marginLeft: -drawerWidth,
+  },
+  contentShift: {
+    transition: theme.transitions.create("margin", {
+      easing: theme.transitions.easing.easeOut,
+      duration: theme.transitions.duration.enteringScreen,
+    }),
+    marginLeft: 0,
+  },
+}));
+
+const Navigation = ({ component, userId, setUserId }) => {
+  const classes = useStyles();
+  const theme = useTheme();
+  const [open, setOpen] = useState(false);
 
   return (
-    <Sidebar
-      sidebar={<NavBar />}
-      open={sidebarOpen}
-      transitions={false}
-      docked={false}
-      onSetOpen={setSidebarOpen}
-      touch={false}
-    >
-      {userId != null && (
-        <Button color="secondary" onClick={handleClick}>
-          Sign Out
-        </Button>
-      )}
-    </Sidebar>
+    <div className={classes.root}>
+      <CssBaseline />
+      <AppBar
+        position="fixed"
+        className={clsx(classes.appBar, {
+          [classes.appBarShift]: open,
+        })}
+      >
+        <Toolbar>
+          <IconButton
+            color="inherit"
+            aria-label="open drawer"
+            onClick={() => setOpen(true)}
+            edge="start"
+            className={clsx(classes.menuButton, open && classes.hide)}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" noWrap>
+            CS 411 Exercise Tracker
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <Drawer
+        className={classes.drawer}
+        variant="persistent"
+        anchor="left"
+        open={open}
+        classes={{
+          paper: classes.drawerPaper,
+        }}
+      >
+        <div className={classes.drawerHeader}>
+          <IconButton onClick={() => setOpen(false)}>
+            {theme.direction === "ltr" ? (
+              <ChevronLeftIcon />
+            ) : (
+              <ChevronRightIcon />
+            )}
+          </IconButton>
+        </div>
+        <NavBar userId={userId} setUserId={setUserId} />
+      </Drawer>
+      <main
+        className={clsx(classes.content, {
+          [classes.contentShift]: open,
+        })}
+      >
+        <div className={classes.drawerHeader} />
+        {component}
+      </main>
+    </div>
   );
 };
 
 export default Navigation;
-
-// <Button onClick={() => {setSidebarOpen(true)}}>
-//           Open sidebar
-//         </Button>

--- a/client/src/components/SettingsPage.js
+++ b/client/src/components/SettingsPage.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PersonIcon from "@material-ui/icons/Person";
 
 function SettingsPage() {
   return (

--- a/client/src/components/SettingsPage.js
+++ b/client/src/components/SettingsPage.js
@@ -1,10 +1,39 @@
-import React from "react";
+import React, { useCallback } from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@material-ui/core";
+import ClearIcon from "@material-ui/icons/Clear";
 import PersonIcon from "@material-ui/icons/Person";
 
+// Stylesheet
+import "../css/Settings.css";
+
 function SettingsPage() {
+  // TODO: Populate name with data from api
+
+  const handleDelete = useCallback(() => {
+    // TODO: call api to delete user
+  }, []);
+
   return (
-    <div>
-      <h1>This is the settings page</h1>
+    <div className="main">
+      <h1>Jackie Osborn</h1>
+      <div>
+        <Link
+          className="link"
+          to={{ pathname: "/profile", state: { isEditing: true } }}
+        >
+          <Button startIcon={<PersonIcon />}>Edit Profile</Button>
+        </Link>
+      </div>
+      <div>
+        <Button
+          color="secondary"
+          onClick={handleDelete}
+          startIcon={<ClearIcon />}
+        >
+          Delete Account
+        </Button>
+      </div>
     </div>
   );
 }

--- a/client/src/components/UserProfile.js
+++ b/client/src/components/UserProfile.js
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from "react";
+import { Link } from "react-router-dom";
 import {
   Button,
   Input,
@@ -13,9 +14,8 @@ import SettingsIcon from "@material-ui/icons/Settings";
 
 //Stylesheet
 import "../css/Profile.css";
-import { Link } from "react-router-dom";
 
-function UserProfile() {
+function UserProfile({ location }) {
   // TODO: populate data from profile api call
   const [profile, setProfile] = useState({
     firstName: "Jackie",
@@ -26,7 +26,9 @@ function UserProfile() {
     height: 70,
   });
   const [editingProfile, setEditingProfile] = useState(profile);
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(
+    location.state ? location.state.isEditing : false
+  );
 
   const handleEdit = useCallback(() => {
     if (isEditing) {
@@ -150,7 +152,7 @@ function UserProfile() {
       <div className="B">
         <div>
           <Button
-            color="primary"
+            color={isEditing ? "primary" : "default"}
             onClick={handleEdit}
             startIcon={isEditing ? <SaveIcon /> : <EditIcon />}
           >
@@ -158,7 +160,7 @@ function UserProfile() {
           </Button>
           {isEditing && (
             <Button
-              color="primary"
+              color="secondary"
               onClick={handleCancel}
               startIcon={<ClearIcon />}
             >
@@ -168,9 +170,7 @@ function UserProfile() {
         </div>
         <div>
           <Link className="link" to="/settings">
-            <Button color="primary" startIcon={<SettingsIcon />}>
-              Settings
-            </Button>
+            <Button startIcon={<SettingsIcon />}>Settings</Button>
           </Link>
         </div>
       </div>

--- a/client/src/components/UserProfile.js
+++ b/client/src/components/UserProfile.js
@@ -1,13 +1,179 @@
-import React from "react";
+import React, { useCallback, useState } from "react";
+import {
+  Button,
+  Input,
+  InputAdornment,
+  MenuItem,
+  TextField,
+} from "@material-ui/core";
+import ClearIcon from "@material-ui/icons/Clear";
+import EditIcon from "@material-ui/icons/Edit";
+import SaveIcon from "@material-ui/icons/Save";
+import SettingsIcon from "@material-ui/icons/Settings";
 
 //Stylesheet
 import "../css/Profile.css";
+import { Link } from "react-router-dom";
 
 function UserProfile() {
+  // TODO: populate data from profile api call
+  const [profile, setProfile] = useState({
+    firstName: "Jackie",
+    lastName: "Osborn",
+    gender: "Female",
+    age: 20,
+    weight: 130,
+    height: 70,
+  });
+  const [editingProfile, setEditingProfile] = useState(profile);
+  const [isEditing, setIsEditing] = useState(false);
+
+  const handleEdit = useCallback(() => {
+    if (isEditing) {
+      // TODO: call api to save profile, if error set error message
+      setProfile(editingProfile);
+      setIsEditing(false);
+    } else {
+      setEditingProfile(profile);
+      setIsEditing(true);
+    }
+  }, [editingProfile, isEditing, profile]);
+
+  const handleCancel = useCallback(() => {
+    setEditingProfile(profile);
+    setIsEditing(false);
+  }, [profile]);
+
   return (
-    <div class="grid-container-profile">
-      <div class="A"></div>
-      <div class="B"></div>
+    <div className="grid-container-profile">
+      <div className="A">
+        <div className="row">
+          <TextField
+            id="standard-basic"
+            disabled={!isEditing}
+            value={editingProfile.firstName}
+            onChange={(e) =>
+              setEditingProfile({
+                ...editingProfile,
+                firstName: e.target.value,
+              })
+            }
+          />
+          <TextField
+            id="standard-basic"
+            disabled={!isEditing}
+            value={editingProfile.lastName}
+            onChange={(e) =>
+              setEditingProfile({ ...editingProfile, lastName: e.target.value })
+            }
+          />
+        </div>
+        <div className="row">
+          <Input
+            className="age"
+            id="standard-adornment-weight"
+            type="number"
+            disabled={!isEditing}
+            value={editingProfile.age}
+            endAdornment={
+              <InputAdornment position="end">years old</InputAdornment>
+            }
+            onChange={(e) =>
+              setEditingProfile({
+                ...editingProfile,
+                age: e.target.value,
+              })
+            }
+          />
+        </div>
+        <div className="row">
+          <TextField
+            className="gender"
+            id="standard-adornment-weight"
+            select
+            disabled={!isEditing}
+            value={editingProfile.gender}
+            endAdornment={
+              <InputAdornment position="end">years old</InputAdornment>
+            }
+            onChange={(e) =>
+              setEditingProfile({
+                ...editingProfile,
+                gender: e.target.value,
+              })
+            }
+          >
+            <MenuItem key="male" value="Male">
+              Male
+            </MenuItem>
+            <MenuItem key="female" value="Female">
+              Female
+            </MenuItem>
+            <MenuItem key="other" value="Other">
+              Other
+            </MenuItem>
+          </TextField>
+        </div>
+        <div className="row">
+          <Input
+            className="weight"
+            id="standard-adornment-weight"
+            type="number"
+            disabled={!isEditing}
+            value={editingProfile.weight}
+            endAdornment={<InputAdornment position="end">lbs</InputAdornment>}
+            onChange={(e) =>
+              setEditingProfile({
+                ...editingProfile,
+                weight: e.target.value,
+              })
+            }
+          />
+          <Input
+            className="height"
+            id="standard-adornment-weight"
+            type="number"
+            disabled={!isEditing}
+            value={editingProfile.height}
+            endAdornment={
+              <InputAdornment position="end">inches</InputAdornment>
+            }
+            onChange={(e) =>
+              setEditingProfile({
+                ...editingProfile,
+                height: e.target.value,
+              })
+            }
+          />
+        </div>
+      </div>
+      <div className="B">
+        <div>
+          <Button
+            color="primary"
+            onClick={handleEdit}
+            startIcon={isEditing ? <SaveIcon /> : <EditIcon />}
+          >
+            {isEditing ? "Save Profile" : "Edit Profile"}
+          </Button>
+          {isEditing && (
+            <Button
+              color="primary"
+              onClick={handleCancel}
+              startIcon={<ClearIcon />}
+            >
+              Cancel
+            </Button>
+          )}
+        </div>
+        <div>
+          <Link className="link" to="/settings">
+            <Button color="primary" startIcon={<SettingsIcon />}>
+              Settings
+            </Button>
+          </Link>
+        </div>
+      </div>
     </div>
   );
 }

--- a/client/src/css/Profile.css
+++ b/client/src/css/Profile.css
@@ -6,12 +6,10 @@ body,
 }
 
 .grid-container-profile * {
-  border: 1px solid red;
   position: relative;
 }
 
 .grid-container-profile *:after {
-  content: attr(class);
   position: absolute;
   top: 0;
   left: 0;
@@ -31,4 +29,31 @@ body,
 
 .B {
   grid-area: B;
+}
+
+.link,
+.link:hover {
+  text-decoration: none;
+}
+
+.row {
+  margin-bottom: 1em;
+  padding-left: 5em;
+}
+
+.age {
+  width: 10em;
+}
+
+.gender {
+  width: 11.4em;
+}
+
+.weight {
+  width: 10em;
+}
+
+.height {
+  margin-left: 2em;
+  width: 10em;
 }

--- a/client/src/css/Settings.css
+++ b/client/src/css/Settings.css
@@ -1,0 +1,8 @@
+.main {
+  text-align: center;
+}
+
+.link,
+link:hover {
+  text-decoration: none;
+}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1175,7 +1175,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@>=7.0.0-beta.56", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
   integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
@@ -1517,6 +1517,13 @@
     prop-types "^15.7.2"
     react-is "^16.8.0"
     react-transition-group "^4.3.0"
+
+"@material-ui/icons@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.9.1.tgz#fdeadf8cb3d89208945b33dbc50c7c616d0bd665"
+  integrity sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
 
 "@material-ui/styles@^4.9.6":
   version "4.9.6"
@@ -9315,14 +9322,6 @@ react-scripts@3.4.1:
     workbox-webpack-plugin "4.3.1"
   optionalDependencies:
     fsevents "2.1.2"
-
-react-sidebar@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-sidebar/-/react-sidebar-3.0.2.tgz#cf695b5a78098e70460c847fb0c6c81cfd896c37"
-  integrity sha512-LG/JO1cJvdRqSmUT+DOhJrml/b45/UqM9nm8emcgbJb5EKNegKCObZcrRqyzVix42VfFf0odytviAAFEYYTu1Q==
-  dependencies:
-    "@babel/runtime" ">=7.0.0-beta.56"
-    prop-types "^15.6.2"
 
 react-transition-group@^2.3.1:
   version "2.9.0"


### PR DESCRIPTION
This PR:
* Utilizes material-ui's `Drawer` for our navbar
* Resolves #19 (makes the nav links links instead of hrefs, makes it so there is no view obstructions)
* Implements a basic page where a user can view their profile details and edit the values (pending api)
* Implements a basic settings page where a user can go edit their profile and click a button to delete their profile (pending api)